### PR TITLE
Allow for redirects

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,7 +55,7 @@ def get():
     return Titled('web2md', frm, Script(js), Div(id='details'), set_cm(samp), gist_form)
 
 def get_body(url):
-    body = lxml.html.fromstring(httpx.get(url).text).xpath('//body')[0]
+    body = lxml.html.fromstring(httpx.get(url, follow_redirects=True).text).xpath('//body')[0]
     body = Cleaner(javascript=True, style=True).clean_html(body)
     return ''.join(lxml.html.tostring(c, encoding='unicode') for c in body)
 


### PR DESCRIPTION
Fixes (I believe) errors when sites contain redirects. [This link](https://bytes.swiggy.com/reflecting-on-a-year-of-generative-ai-at-swiggy-a-brief-review-of-achievements-learnings-and-13a9671dc624) e.g. doesn't work in https://web2md.answer.ai/ and same with the underlying Python implementation when you strip it out. A minimal example showing the fix works:

```python
import httpx


def get_body_before(url):
    """Original version without follow_redirects"""
    return httpx.get(url).text

def get_body_after(url):
    """Fixed version with follow_redirects=True"""
    return httpx.get(url, follow_redirects=True).text

# Test URL that involves a redirect
test_url = "https://bytes.swiggy.com/reflecting-on-a-year-of-generative-ai-at-swiggy-a-brief-review-of-achievements-learnings-and-13a9671dc624"

print("Without follow_redirects:")
try:
    response_before = get_body_before(test_url)
    print(f"Response length: {len(response_before)}")
    print("First 100 characters:", response_before[:100])
except Exception as e:
    print(f"Error: {e}")

print("\nWith follow_redirects=True:")
try:
    response_after = get_body_after(test_url)
    print(f"Response length: {len(response_after)}")
    print("First 100 characters:", response_after[:100])
except Exception as e:
    print(f"Error: {e}")
```

![CleanShot 2024-11-18 at 17 13 21@2x](https://github.com/user-attachments/assets/0839f0fd-a8de-4dae-a888-246600255303)
